### PR TITLE
Update package set

### DIFF
--- a/packages.dhall
+++ b/packages.dhall
@@ -119,11 +119,10 @@ let additions =
 
 
 let upstream =
-      https://github.com/purescript/package-sets/releases/download/psc-0.13.3-20190831/packages.dhall sha256:852cd4b9e463258baf4e253e8524bcfe019124769472ca50b316fe93217c3a47
-
+      https://github.com/purescript/package-sets/releases/download/psc-0.13.5-20191127/packages.dhall sha256:654e8427ff1f9830542f491623cd5d89b1648774a765520554f98f41d3d1b3b3
 
 let overrides =
-    { spec-discovery =
+      { spec-discovery =
               upstream.spec-discovery
           //  { repo =
                   "https://github.com/reactormonk/purescript-spec-discovery.git"
@@ -132,10 +131,10 @@ let overrides =
               }
       , spec =
           upstream.spec // { version = "v3.1.1" }
-    }
+      }
 
-let additions = {
-    aff-retry =
+let additions =
+      { aff-retry =
           { dependencies =
               [ "aff"
               , "transformers"
@@ -149,7 +148,7 @@ let additions = {
           , version =
               "fa0814127c8f0ce95ecc98537f5d58cbd7d0a71c"
           }
-    , flow-id =
+      , flow-id =
           { dependencies =
               [ "prelude", "simple-json" ]
           , repo =
@@ -157,6 +156,6 @@ let additions = {
           , version =
               "v1.0.0"
           }
-    }
+      }
 
 in  upstream // overrides // additions

--- a/src/Nakadi/Client.purs
+++ b/src/Nakadi/Client.purs
@@ -35,7 +35,7 @@ import Effect.Class (liftEffect)
 import Effect.Class.Console as Console
 import Effect.Exception (Error)
 import Foreign.Object as Object
-import Nakadi.Client.Internal (catchErrors, deleteRequest, deserialise, deserialiseProblem, deserialise_, getRequest, postRequest, putRequest, readJson, request, unhandled)
+import Nakadi.Client.Internal (catchErrors, deleteRequest, deserialise, deserialiseProblem, deserialise_, formatErr, getRequest, postRequest, putRequest, readJson, request, unhandled)
 import Nakadi.Client.Stream (CommitResult, StreamReturn(..), postStream)
 import Nakadi.Client.Types (Env, NakadiResponse, LogWarnFn)
 import Nakadi.Errors (E207, E400, E403, E404, E409(..), E422(..), E422Publish, _conflict, _unprocessableEntity, e207, e400, e401, e403, e404, e409, e422, e422Publish)
@@ -164,21 +164,25 @@ postEvents
   -> m (NakadiResponse (multiStatus ∷ E207, forbidden ∷ E403, notFound ∷ E404, unprocessableEntityPublish ∷ E422Publish) Unit)
 postEvents (EventTypeName name) events = do
   let path = "/event-types/" <> name <> "/events"
-  { body, status: StatusCode statusCode } <- postRequest path events >>= request
-  res1 <- case statusCode of
-    code | code == 422 || code == 207 -> map Just <$> readJson body
-    code | code # between 200 299 -> (pure <<< pure) Nothing
-    _ -> deserialiseProblem body
-  res2 <- res1 # catchErrors case _ of -- is this all correct?
-    p @ { status: 403 } -> pure $ lmap e403 res1
-    p @ { status: 404 } -> pure $ lmap e404 res1
-    p -> unhandled p
-  pure $ res2 >>= case _ of
-    Just batchProblem ->
-      if statusCode == 207
-      then Left $ e207 batchProblem -- this is treated as an error
-      else Left $ e422Publish batchProblem
-    Nothing -> Right unit
+  response <- postRequest path events >>= request
+  case response of
+    Right { body, status: StatusCode statusCode } -> do
+      res1 <- case statusCode of
+        code | code == 422 || code == 207 -> map Just <$> readJson body
+        code | code # between 200 299 -> (pure <<< pure) Nothing
+        _ -> deserialiseProblem body
+      res2 <- res1 # catchErrors case _ of -- is this all correct?
+        p @ { status: 403 } -> pure $ lmap e403 res1
+        p @ { status: 404 } -> pure $ lmap e404 res1
+        p -> unhandled p
+      pure $ res2 >>= case _ of
+        Just batchProblem ->
+          if statusCode == 207
+          then Left $ e207 batchProblem -- this is treated as an error
+          else Left $ e422Publish batchProblem
+        Nothing -> Right unit
+    Left error ->
+      formatErr error
 
 postSubscription
   ∷ ∀ r m


### PR DESCRIPTION
purescript-affjax v10.0.0
> All request functions now return Either Error _ - the Aff error channel is no longer used to capture errors from the XHR object, and the provided Error type captures the various possible error cases that can occur.
